### PR TITLE
ASSETS_URL changement https

### DIFF
--- a/src/main/java/fr/trxyy/alternative/alternative_apiv2/updater/GameUpdater.java
+++ b/src/main/java/fr/trxyy/alternative/alternative_apiv2/updater/GameUpdater.java
@@ -91,7 +91,7 @@ public class GameUpdater {
 	/**
 	 * The Assets Url
 	 */
-	private static final String ASSETS_URL = "http://resources.download.minecraft.net/";
+	private static final String ASSETS_URL = "https://resources.download.minecraft.net/";
 	
 	public GameUpdater(MinecraftVersion mcVersion, GameEngine engin) {
 		this.minecraftVersion = mcVersion;


### PR DESCRIPTION
j'ai changer en https:// car sinon quand on fait le launcher ont as un code d'erreur qui est : le serveur a renvoyé le code de réponse HTTP : 400 for URL: http://resources.download.minecraft.net/13/13beba907bd219f3b2d3f50e716805fa63124cbf en gros quand on va sur la page on ce mange un RequiresHttps en gros il faut le https et quand on teste cela marche correctement https://resources.download.minecraft.net/13/13beba907bd219f3b2d3f50e716805fa63124cbf